### PR TITLE
Impementing transport mode and TCPclient interface

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,20 +18,21 @@ DEBUG = 2
 # Multiple interfaces can be active at the same time (e.g. WiFi + LoRa).
 CONFIG = {
     "loglevel": 3,
+    "enable_transport": True,
     "interfaces": [
 
         # ---- WiFi UDP ----
         # Broadcasts on the local LAN. Works with MeshChat / Sideband.
         # Set forward_ip to None for auto-detected subnet broadcast.
-        # {
-        #     "type": "UDPInterface",
-        #     "name": "WiFi UDP",
-        #     "enabled": True,
-        #     "listen_ip": "0.0.0.0",
-        #     "listen_port": 4242,
-        #     "forward_ip": "255.255.255.255",
-        #     "forward_port": 4242,
-        # },
+         # {
+         #     "type": "UDPInterface",
+         #     "name": "WiFi UDP",
+         #     "enabled": True,
+         #     "listen_ip": "0.0.0.0",
+         #     "listen_port": 4242,
+         #     "forward_ip": "255.255.255.255",
+         #     "forward_port": 4242,
+         # },
 
         # ---- E220 LoRa (EByte E220-900T) ----
         # Transparent serial LoRa. Both nodes must share channel and air_rate.
@@ -92,28 +93,39 @@ CONFIG = {
         # dio2_rf_sw: true = SX1262 internally drives DIO2 as RF switch (default, correct for Wio-SX1262)
         # dio3_tcxo_millivolts: 1800 for Wio-SX1262 TCXO. Set null to disable.
         #
+        # {
+        #     "type": "LoRaInterface",
+        #     "name": "LoRa SX1262",
+        #     "enabled": True,
+        #     "spi_bus": 1,
+        #     "sck_pin": 7,
+        #     "mosi_pin": 9,
+        #     "miso_pin": 8,
+        #     "cs_pin": 41,
+        #     "busy_pin": 40,
+        #     "dio1_pin": 39,
+        #     "reset_pin": 42,
+        #     "freq_khz": 868000,
+        #     "sf": 7,
+        #     "bw": "125",
+        #     "coding_rate": 5,
+        #     "tx_power": 14,
+        #     "preamble_len": 8,
+        #     "crc_en": True,
+        #     "syncword": 0x1424,
+        #     "dio2_rf_sw": True,
+        #     "dio3_tcxo_millivolts": 1800,
+        # },
+
+        # ---- TCP Client ----
+        # Connects to a remote RNS TCP server (TCPServerInterface).
+        # Uses HDLC framing, wire-compatible with reference Reticulum.
         {
-            "type": "LoRaInterface",
-            "name": "LoRa SX1262",
+            "type": "TCPClientInterface",
+            "name": "VarnaTransport",
             "enabled": True,
-            "spi_bus": 1,
-            "sck_pin": 7,
-            "mosi_pin": 9,
-            "miso_pin": 8,
-            "cs_pin": 41,
-            "busy_pin": 40,
-            "dio1_pin": 39,
-            "reset_pin": 42,
-            "freq_khz": 868000,
-            "sf": 7,
-            "bw": "125",
-            "coding_rate": 5,
-            "tx_power": 14,
-            "preamble_len": 8,
-            "crc_en": True,
-            "syncword": 0x1424,
-            "dio2_rf_sw": True,
-            "dio3_tcxo_millivolts": 1800,
+            "target_host": "rn.varnatransport.com",
+            "target_port": 4243,
         },
 
         # ---- Serial (for RNode / wired link) ----

--- a/urns/const.py
+++ b/urns/const.py
@@ -90,6 +90,7 @@ MAX_PATH_TABLE        = const(32)
 MAX_ACTIVE_LINKS      = const(4)
 MAX_ANNOUNCE_QUEUE    = const(16)
 MAX_RECEIPTS          = const(32)
+TRANSPORT_HOPLIMIT    = const(128)
 
 # Timing
 RATCHET_EXPIRY        = const(60 * 60 * 24 * 30)  # 30 days

--- a/urns/interfaces/tcp.py
+++ b/urns/interfaces/tcp.py
@@ -1,0 +1,184 @@
+# µReticulum TCP Client Interface
+# HDLC-framed TCP connection to a remote RNS TCPServerInterface
+
+import time
+import socket
+from . import Interface
+from ..log import log, LOG_VERBOSE, LOG_DEBUG, LOG_ERROR, LOG_NOTICE
+
+# HDLC framing constants (inlined to keep module self-contained)
+FLAG     = 0x7E
+ESC      = 0x7D
+ESC_MASK = 0x20
+
+
+def hdlc_escape(data):
+    """Escape FLAG and ESC bytes in data"""
+    out = bytearray()
+    for b in data:
+        if b == FLAG:
+            out.append(ESC)
+            out.append(FLAG ^ ESC_MASK)
+        elif b == ESC:
+            out.append(ESC)
+            out.append(ESC ^ ESC_MASK)
+        else:
+            out.append(b)
+    return bytes(out)
+
+
+class TCPClientInterface(Interface):
+    HW_MTU = 564
+    CONNECT_TIMEOUT = 5
+    RECONNECT_WAIT = 5
+    MAX_RECONNECTS = 0       # 0 = unlimited
+
+    def __init__(self, config):
+        name = config.get("name", "TCP")
+        super().__init__(name)
+
+        self.target_host = config.get("target_host", "localhost")
+        self.target_port = config.get("target_port", 4242)
+        self.reconnect_wait = config.get("reconnect_wait", self.RECONNECT_WAIT)
+        self.max_reconnects = config.get("max_reconnects", self.MAX_RECONNECTS)
+
+        self._socket = None
+        self._in_frame = False
+        self._escape = False
+        self._buffer = bytearray()
+        self._reconnect_count = 0
+        self._last_reconnect = 0
+
+        try:
+            self._connect()
+        except Exception as e:
+            log("TCP initial connect failed: " + str(e), LOG_ERROR)
+
+    def _connect(self):
+        addr_info = socket.getaddrinfo(self.target_host, self.target_port)
+        addr = addr_info[0][-1]
+
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(self.CONNECT_TIMEOUT)
+        s.connect(addr)
+        s.settimeout(0)
+
+        try:
+            s.setsockopt(socket.IPPROTO_TCP, 1, 1)  # TCP_NODELAY = 1
+        except:
+            pass
+
+        self._socket = s
+        self._in_frame = False
+        self._escape = False
+        self._buffer = bytearray()
+        self.online = True
+        self._reconnect_count = 0
+        log("TCP connected to " + self.target_host + ":" + str(self.target_port), LOG_NOTICE)
+
+    def _close_socket(self):
+        if self._socket:
+            try:
+                self._socket.close()
+            except:
+                pass
+            self._socket = None
+
+    def _reconnect(self):
+        now = time.time()
+        if now - self._last_reconnect < self.reconnect_wait:
+            return
+        self._last_reconnect = now
+
+        if self.max_reconnects > 0 and self._reconnect_count >= self.max_reconnects:
+            log("TCP max reconnect attempts reached", LOG_ERROR)
+            self.enabled = False
+            return
+
+        self._reconnect_count += 1
+        log("TCP reconnecting (" + str(self._reconnect_count) + ")...", LOG_NOTICE)
+        self._close_socket()
+
+        try:
+            self._connect()
+        except Exception as e:
+            log("TCP reconnect failed: " + str(e), LOG_ERROR)
+
+    def process_outgoing(self, data):
+        if not self.online or not self._socket:
+            return False
+
+        try:
+            frame = bytes([FLAG]) + hdlc_escape(data) + bytes([FLAG])
+            self._socket.sendall(frame)
+            self.txb += len(data)
+            self.tx += 1
+            self._last_activity = time.time()
+            return True
+        except Exception as e:
+            log("TCP send error: " + str(e), LOG_ERROR)
+            self.online = False
+            return False
+
+    def _process_byte(self, byte):
+        if self._in_frame and byte == FLAG:
+            self._in_frame = False
+            if len(self._buffer) > 0:
+                self.process_incoming(bytes(self._buffer))
+                self._buffer = bytearray()
+
+        elif byte == FLAG:
+            self._in_frame = True
+            self._buffer = bytearray()
+            self._escape = False
+
+        elif self._in_frame and len(self._buffer) < self.HW_MTU:
+            if byte == ESC:
+                self._escape = True
+            else:
+                if self._escape:
+                    if byte == FLAG ^ ESC_MASK:
+                        byte = FLAG
+                    elif byte == ESC ^ ESC_MASK:
+                        byte = ESC
+                    self._escape = False
+                self._buffer.append(byte)
+
+    async def poll_loop(self):
+        import uasyncio as asyncio
+
+        log("TCP poll loop started for " + self.name, LOG_VERBOSE)
+
+        while self.enabled:
+            if not self.online:
+                self._reconnect()
+                await asyncio.sleep(1)
+                continue
+
+            try:
+                data = self._socket.recv(512)
+                if data:
+                    for b in data:
+                        self._process_byte(b)
+                else:
+                    # Empty recv = connection closed
+                    log("TCP connection closed by remote", LOG_NOTICE)
+                    self.online = False
+            except OSError as e:
+                if e.args[0] == 11:  # EAGAIN
+                    pass
+                else:
+                    log("TCP recv error: " + str(e), LOG_ERROR)
+                    self.online = False
+
+            await asyncio.sleep(0.01)
+
+        log("TCP poll loop EXITED for " + self.name, LOG_ERROR)
+
+    def close(self):
+        super().close()
+        self._close_socket()
+        log("TCP Interface " + self.name + " closed", LOG_VERBOSE)
+
+    def __str__(self):
+        return "TCPClientInterface[" + self.name + "]"

--- a/urns/lxmf.py
+++ b/urns/lxmf.py
@@ -498,7 +498,7 @@ class LXMRouter:
                 peer_data = umsgpack.unpackb(app_data)
                 if isinstance(peer_data, list) and len(peer_data) >= 1:
                     dn = peer_data[0]
-                    if dn is None:
+                    if dn is None or dn is False:
                         return None
                     if isinstance(dn, bytes):
                         return dn.decode("utf-8")

--- a/urns/reticulum.py
+++ b/urns/reticulum.py
@@ -122,15 +122,20 @@ class Reticulum:
     # Map interface type names to their module files.
     # Add new interfaces here: "TypeName": "module_name"
     _INTERFACE_MAP = {
-        "UDPInterface":    "udp",
-        "SerialInterface": "serial",
-        "E220Interface":   "e220",
-        "LoRaInterface":   "lora",
+        "UDPInterface":       "udp",
+        "SerialInterface":    "serial",
+        "E220Interface":      "e220",
+        "LoRaInterface":      "lora",
+        "TCPClientInterface": "tcp",
     }
 
     def setup_interfaces(self):
         """Initialize network interfaces from config. Call after WiFi is connected.
         Only the modules for configured interfaces are imported."""
+        Transport.transport_enabled = self.config.get("enable_transport", False)
+        if Transport.transport_enabled:
+            log("Transport mode enabled", LOG_NOTICE)
+
         for iface_config in self.config.get("interfaces", []):
             if not iface_config.get("enabled", True):
                 continue

--- a/urns/transport.py
+++ b/urns/transport.py
@@ -1,5 +1,5 @@
 # µReticulum Transport
-# Simplified for leaf-node mode (no forwarding)
+# Supports optional transport mode (blind flood forwarding between interfaces)
 # Uses uasyncio instead of threading
 
 import os
@@ -30,6 +30,8 @@ class Transport:
     destination_table = {}
     blackholed_identities = []
 
+    transport_enabled = False
+
     _jobs_running = False
     _last_job = 0
 
@@ -37,8 +39,12 @@ class Transport:
     def start(owner):
         Transport.owner = owner
         Transport.identity = owner.identity
+        Transport.transport_enabled = owner.config.get("enable_transport", False)
         Transport._jobs_running = True
-        log("Transport engine started", LOG_VERBOSE)
+        if Transport.transport_enabled:
+            log("Transport engine started — TRANSPORT MODE", LOG_NOTICE)
+        else:
+            log("Transport engine started", LOG_VERBOSE)
 
     @staticmethod
     def stop():
@@ -126,6 +132,28 @@ class Transport:
         Transport.packet_hashlist.append(packet_hash)
 
     @staticmethod
+    def _forward(raw, receiving_interface):
+        """Forward raw packet to all interfaces except the one it arrived on"""
+        hops = raw[1]
+        if hops >= const.TRANSPORT_HOPLIMIT:
+            log("Forward: hop limit reached (" + str(hops) + "), dropping", LOG_DEBUG)
+            return
+
+        fwd = bytearray(raw)
+        fwd[1] = hops + 1
+
+        for interface in Transport.interfaces:
+            if interface is receiving_interface:
+                continue
+            if not interface.online:
+                continue
+            try:
+                interface.process_outgoing(fwd)
+                log("Forward: " + str(len(fwd)) + "B " + receiving_interface.name + " -> " + interface.name + " hops=" + str(fwd[1]), LOG_DEBUG)
+            except Exception as e:
+                log("Forward error on " + interface.name + ": " + str(e), LOG_ERROR)
+
+    @staticmethod
     def inbound(raw, interface=None):
         """Process an incoming raw packet from an interface"""
         from .packet import Packet
@@ -166,18 +194,21 @@ class Transport:
             Transport._cache_packet_hash(packet)
 
             # Route the packet
+            local = False
             if packet.packet_type == const.PKT_ANNOUNCE:
                 log("Inbound: processing announce", LOG_DEBUG)
                 Transport._handle_announce(packet)
-
             elif packet.packet_type == const.PKT_LINKREQUEST:
-                Transport._handle_linkrequest(packet)
-
+                local = Transport._handle_linkrequest(packet)
             elif packet.packet_type == const.PKT_DATA:
-                Transport._handle_data(packet)
-
+                local = Transport._handle_data(packet)
             elif packet.packet_type == const.PKT_PROOF:
-                Transport._handle_proof(packet)
+                local = Transport._handle_proof(packet)
+
+            # Forward: announces always, other types only if not consumed locally
+            if Transport.transport_enabled and interface is not None:
+                if packet.packet_type == const.PKT_ANNOUNCE or not local:
+                    Transport._forward(raw, interface)
 
         except Exception as e:
             log("Error processing inbound packet: " + str(e), LOG_ERROR)
@@ -211,7 +242,8 @@ class Transport:
         for dest in Transport.destinations:
             if dest.hash == packet.destination_hash:
                 dest.receive(packet)
-                return
+                return True
+        return False
 
     @staticmethod
     def _handle_data(packet):
@@ -219,12 +251,13 @@ class Transport:
         for dest in Transport.destinations:
             if dest.hash == packet.destination_hash:
                 dest.receive(packet)
-                return
+                return True
         # Check active links
         for link in Transport.active_links:
             if link.link_id == packet.destination_hash:
                 link.receive(packet)
-                return
+                return True
+        return False
 
     @staticmethod
     def _handle_proof(packet):
@@ -233,12 +266,13 @@ class Transport:
             for link in Transport.pending_links:
                 if link.link_id == packet.destination_hash:
                     link.validate_proof(packet)
-                    return
+                    return True
         else:
             # Regular proof - check receipts
             for receipt in Transport.receipts:
                 if receipt.validate_proof_packet(packet):
-                    return
+                    return True
+        return False
 
     @staticmethod
     def hops_to(destination_hash):


### PR DESCRIPTION
 ## Summary

  - **Transport mode**: µReticulum can now forward packets between interfaces (blind flood), enabling it to act as a bridge — e.g. between WiFi UDP and a remote TCP hub, or between
  LoRa and WiFi. Controlled by `"enable_transport": true` in config.
  - **TCP client interface**: New `TCPClientInterface` connects to remote RNS `TCPServerInterface` nodes over the internet. Uses HDLC framing (same as serial), wire-compatible with
  reference Reticulum. Supports auto-reconnect on disconnect.
  - **Minor fix**: LXMF display name extraction now handles `False` in addition to `None` (seen in some real-world announce app_data).

  ## Changes

  ### Transport mode (`urns/transport.py`)
  - Added `transport_enabled` flag, read from config `enable_transport`
  - New `_forward()` method: increments hop count, sends raw packet to all interfaces except the one it arrived on, respects `TRANSPORT_HOPLIMIT` (128)
  - Forwarding logic: announces are always forwarded; data/proof/linkrequest are only forwarded if not consumed locally
  - `_handle_data`, `_handle_linkrequest`, `_handle_proof` now return `True`/`False` to indicate local consumption

  ### TCP client interface (`urns/interfaces/tcp.py` — new file)
  - HDLC framing with inlined constants (no dependency on `serial.py`)
  - Byte-by-byte RX state machine (same proven pattern as `SerialInterface`)
  - Non-blocking recv via `settimeout(0)` + EAGAIN handling
  - Auto-reconnect with configurable wait and max retries (default: unlimited)
  - `TCP_NODELAY` set where supported
  - Config: `target_host`, `target_port`, `reconnect_wait`, `max_reconnects`

  ### Other
  - `urns/const.py`: Added `TRANSPORT_HOPLIMIT = 128`
  - `urns/reticulum.py`: Registered `TCPClientInterface` in interface map; reads `enable_transport` from config during `setup_interfaces()`
  - `urns/lxmf.py`: Handle `False` display name in announce app_data
  - `config.py`: Added TCP client example config, enabled transport mode, commented out LoRa SX1262 config

  ## Test plan
  - [ ] Configure `TCPClientInterface` pointing at a reference RNS node running `TCPServerInterface`
  - [ ] Boot ESP32 → verify "TCP connected to host:port" in logs
  - [ ] Remote node announces → arrives over TCP → visible in announce handler
  - [ ] Send LXMF message via TCP → proof arrives back
  - [ ] Kill TCP server → verify reconnect attempts → restart server → connection restored
  - [ ] With transport enabled + two interfaces (e.g. WiFi UDP + TCP): announce arrives on TCP → forwarded to WiFi (and vice versa)