### PR TITLE
Added Nomadnet page server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ Requires MicroPython 1.22+. Should also work on other ESP32-S3 boards and Raspbe
 - **Announce & Discovery** — ESP32 announces itself with an LXMF-compatible display name. Appears in MeshChat's network visualizer. Receives and parses announces from other peers.
 - **Full Crypto Stack** — X25519 key exchange, Ed25519 signatures, AES-128-CBC encryption, HKDF, HMAC-SHA256 — all in pure Python, no C extensions.
 - **Wire Protocol** — Byte-identical packet format to reference Reticulum. Validated bidirectionally against the reference implementation.
+- **NomadNet Page Serving** — Serve micron-format pages to NomadNet clients over Reticulum Links. Full ECDH link handshake with request/response RPC for small pages (< ~350 bytes).
+- **Transport Mode** — Blind flood forwarding between interfaces. Bridge WiFi and LoRa so packets from one interface are relayed to all others.
 - **UDP Interface** — WiFi networking with auto-detected subnet broadcast. Non-blocking async I/O with ESP32 socket recovery.
+- **TCP Client Interface** — HDLC-framed TCP connection to remote RNS transport servers. Enables long-range connectivity beyond the local LAN.
 - **SX1262 SPI LoRa Interface** — Native SPI control of SX1262 LoRa radios (e.g. Seeed XIAO ESP32S3 + Wio-SX1262). Interoperates with RNode (SX1276/SX1278) and reference Reticulum over LoRa — bidirectional LXMF messaging, announces, and delivery proofs all work. Built-in fragmentation for Reticulum's 500-byte MTU over 255-byte LoRa packets. RSSI/SNR reporting.
 - **Serial Interface** — HDLC-framed UART for RNode, LoRa radios, packet radio TNCs, or ESP32-to-ESP32 links.
 - **Persistent Identity** — Keys and known destinations survive reboots. JSON configuration.
@@ -74,6 +77,8 @@ Commands are case-insensitive. Any other message is echoed back as a reply. This
 ```
 ureticulum/
 ├── example_node.py          # LXMF messaging node with NeoPixel control
+├── example_nomadnet_node.py # NomadNet page-serving node
+├── config.py                # Node configuration (WiFi, interfaces)
 ├── urns/
 │   ├── __init__.py          # Package entry point
 │   ├── const.py             # Protocol constants (matching reference RNS)
@@ -82,12 +87,14 @@ ureticulum/
 │   ├── destination.py       # Destination addressing, encryption, announce sending
 │   ├── packet.py            # Packet framing, proof generation, receipts
 │   ├── transport.py         # Packet routing, announce handling, interface management
+│   ├── link.py              # Server-side Reticulum Links (ECDH handshake, request/response)
 │   ├── lxmf.py              # LXMF message format, LXMessage, LXMRouter
 │   ├── umsgpack.py          # Minimal MessagePack (subset needed for LXMF)
 │   ├── log.py               # Logging with configurable verbosity
 │   ├── interfaces/
 │   │   ├── __init__.py      # Base Interface class
 │   │   ├── udp.py           # WiFi UDP with broadcast discovery
+│   │   ├── tcp.py           # HDLC-framed TCP client (for RNS transport servers)
 │   │   ├── serial.py        # HDLC-framed UART (RNode, LoRa, ESP-to-ESP)
 │   │   └── lora.py          # SX1262 SPI LoRa with fragmentation
 │   └── crypto/
@@ -290,17 +297,117 @@ mpremote mip install lora-sx126x
 
 **Fragmentation:** The SX1262 has a 255-byte packet limit while Reticulum's MTU is 500 bytes. The interface automatically fragments and reassembles packets — no configuration needed.
 
-See `config.py` for all config variants (UDP-only, LoRa-only, dual WiFi+LoRa). Set `CONFIG` at the bottom to choose the active one.
+### TCP Client Interface
+
+Connects to a remote RNS TCP server (e.g. a transport node). Uses HDLC framing, wire-compatible with reference Reticulum's `TCPServerInterface`. Auto-reconnects on connection loss.
+
+```json
+{
+  "type": "TCPClientInterface",
+  "name": "Transport Hub",
+  "enabled": true,
+  "target_host": "rn.example.com",
+  "target_port": 4243
+}
+```
+
+### Transport Mode
+
+Enable transport mode to relay packets between interfaces. This turns your ESP32 into a bridge — for example, forwarding between WiFi and LoRa so that LoRa-only nodes can reach the wider network.
+
+```json
+{
+  "enable_transport": true,
+  "interfaces": [
+    { "type": "UDPInterface", ... },
+    { "type": "LoRaInterface", ... }
+  ]
+}
+```
+
+Transport uses blind flood forwarding: packets received on one interface are re-sent on all others (with hop count incremented). No path computation or routing tables — simple and RAM-friendly.
+
+See `config.py` for all config variants (UDP, LoRa, TCP, dual WiFi+LoRa). Uncomment the interfaces you need.
+
+## NomadNet Page Serving
+
+µReticulum can serve [micron-format](https://github.com/markqvist/NomadNet) pages to NomadNet clients over Reticulum Links. This requires the full ECDH link handshake (3-packet exchange), after which the client can request pages via RPC.
+
+### Running the NomadNet Node
+
+1. Edit `config.py` with your WiFi credentials and interfaces
+2. Copy `urns/`, `config.py`, `pages/`, and `example_nomadnet_node.py` to the device
+3. Run:
+   ```python
+   import example_nomadnet_node
+   ```
+
+The node announces as `nomadnetwork.node` and serves pages from the `pages/` directory. Open NomadNet or MeshChat on another machine, discover the node, and browse to it.
+
+### Page Files
+
+Pages are `.mu` files in the `pages/` directory using NomadNet's [micron markup format](https://github.com/markqvist/NomadNet). Each file is automatically registered as a request handler at `/page/<filename>`.
+
+Example `pages/index.mu`:
+```
+>Welcome to {node_name}
+
+This node is running uReticulum on an ESP32.
+
+>> Status
+  Free memory: {mem_free}
+  Uptime: {uptime}
+```
+
+Supported template variables (substituted at serve time):
+
+| Variable | Description | Example output |
+|----------|-------------|----------------|
+| `{node_name}` | Node display name from config | `ESP32s3` |
+| `{mem_free}` | Free heap memory (human-readable) | `7.6 MB` |
+| `{uptime}` | Time since boot | `2h 15m 30s` |
+
+To add more pages, just drop `.mu` files into `pages/` — they are picked up automatically on boot. For example, `pages/about.mu` would be served at `/page/about.mu`.
+
+### Page Size Limits
+
+Pages are served as single encrypted link packets. After encryption overhead (AES-256-CBC IV, PKCS7 padding, HMAC-SHA256) and Reticulum packet headers, the maximum page content is **~350 bytes**. This is sufficient for status pages and short informational content.
+
+Pages exceeding this limit will be rejected with a log error. Serving larger pages would require Reticulum's Resource transfer protocol, which is not yet implemented.
+
+### Link Handshake
+
+When a NomadNet client connects, the following exchange occurs:
+
+```
+NomadNet Client                     ESP32 (µReticulum)
+   │                                       │
+   ├─ Link Request (X25519 pub key) ─────► │ Generate ephemeral X25519 keypair (~2s)
+   │                                       │ ECDH shared secret → HKDF → AES-256 Token
+   │                                       │
+   │ ◄───── Link Proof (signature + pub) ──┤ Sign with destination Ed25519 identity
+   │                                       │
+   ├─ RTT (encrypted) ──────────────────► │ Link ACTIVE
+   │                                       │
+   ├─ Page Request (encrypted RPC) ──────► │ Decrypt, look up handler by path hash
+   │                                       │ Read .mu file, substitute variables
+   │ ◄──────── Page Response (encrypted) ──┤ Encrypt and send
+   │                                       │
+```
+
+Each link consumes ~350 bytes of RAM. Up to 4 concurrent links are supported (`MAX_ACTIVE_LINKS=4`). Idle links are automatically cleaned up after 12 minutes.
 
 ## Compatibility
 
 Tested and confirmed working with:
 
 - **MeshChat** — Bi-directional announces, opportunistic messaging, delivery receipts
-- **Sideband / NomadNet** — Peer discovery, LXMF messaging
-- **Reference Reticulum** (Python) — Wire-compatible packets, announces, encryption
+- **Sideband** — Peer discovery, LXMF messaging
+- **NomadNet** — Peer discovery, LXMF messaging, page serving over Links
+- **Reference Reticulum** (Python) — Wire-compatible packets, announces, encryption, link handshake
 - **Reference LXMF** — Cross-validated message packing/unpacking, signature verification
 - **RNode** (SX1276/SX1278) — Bidirectional LoRa: announces, encrypted LXMF messages, delivery proofs. Tested with Heltec Wireless Stick Lite V1 running RNode firmware on 868 MHz
+- **RNS Transport Servers** — TCP client connectivity to remote transport hubs
 
 ## ESP32 Socket Workarounds
 
@@ -326,9 +433,10 @@ The driver source code appears correct (it uses `n_read=1` to consume the SX1262
 ## Limitations
 
 - **MicroPython only** — no CPython/desktop support. Uses `uhashlib`, `ucryptolib`, `uasyncio`, `micropython.const` directly.
-- **Opportunistic delivery only** — Single-packet messages up to ~295 bytes content. Link-based delivery (for larger messages) is not yet implemented.
+- **Opportunistic LXMF only** — Single-packet messages up to ~295 bytes content. Link-based LXMF delivery (for larger messages) requires Resource transfer, which is not yet implemented.
+- **Small pages only** — NomadNet page responses must fit in a single link packet (~350 bytes). Resource transfer for larger pages is not yet implemented.
+- **Server-side links only** — Can accept incoming links (for page serving), but cannot initiate outbound links.
 - **No propagation nodes** — Cannot store-and-forward messages for offline peers.
-- **No transport nodes** — Cannot relay packets between interfaces (single-interface only).
 - **Pure Python crypto** — ~4 second message round-trip on ESP32. `@micropython.viper` could significantly speed this up.
 
 ## What's Next
@@ -336,8 +444,8 @@ The driver source code appears correct (it uses `n_read=1` to consume the SX1262
 Potential areas for expansion:
 
 - **Viper-accelerated crypto** — `@micropython.viper` native compilation for field arithmetic could bring X25519 from ~1.4s to ~0.2s
-- **Link-based delivery** — Support for messages larger than a single packet
-- **Multi-interface routing** — Bridge WiFi <-> LoRa for mesh relay
+- **Resource transfer** — Multi-packet streaming over Links for large pages and link-based LXMF delivery
+- **Client-side links** — Initiate outbound links for direct LXMF delivery
 - **More hardware control** — Expand NeoPixel example to sensors, relays, displays
 - **Propagation node** — Store-and-forward for offline peers
 

--- a/example_nomadnet_node.py
+++ b/example_nomadnet_node.py
@@ -1,0 +1,211 @@
+"""
+µReticulum Example: NomadNet Page-Serving Node
+================================================
+Serves simple micron-format pages to NomadNet clients over Reticulum Links.
+Pages are loaded from the pages/ directory as .mu (micron format) files.
+
+Supported template variables in .mu files:
+  {node_name}  — node display name from config
+  {mem_free}   — free heap memory in bytes
+  {uptime}     — system uptime in seconds (epoch)
+
+Usage (MicroPython on ESP32/Pico W):
+  1. Edit config.py — set WiFi credentials and interfaces
+  2. Copy the urns/ folder, config.py, pages/, and this file to the device
+  3. Run with: import example_nomadnet_node
+"""
+
+from config import WIFI_SSID, WIFI_PASS, NODE_NAME, DEBUG, CONFIG
+
+import gc
+import time
+gc.collect()
+_boot_time = time.time()
+
+
+def connect_wifi(ssid, password, timeout=15):
+    import sys
+    import network
+    import time
+
+    platform = sys.platform
+
+    if platform == "esp32":
+        ap = network.WLAN(network.AP_IF)
+        if ap.active():
+            ap.active(False)
+
+    wlan = network.WLAN(network.STA_IF)
+    wlan.active(True)
+    if not wlan.isconnected():
+        if DEBUG >= 1:
+            print("Connecting to WiFi:", ssid)
+        wlan.connect(ssid, password)
+        start = time.time()
+        while not wlan.isconnected():
+            if time.time() - start > timeout:
+                raise RuntimeError("WiFi connection timed out")
+            time.sleep(0.5)
+
+    if platform == "esp32":
+        wlan.config(pm=0)
+    elif platform == "rp2":
+        wlan.config(pm=0xa11140)
+
+    ip = wlan.ifconfig()[0]
+    if DEBUG >= 1:
+        print("Connected! IP:", ip)
+    return ip
+
+
+def load_pages(dest, pages_dir="pages"):
+    """Load .mu pages from a directory and register them as request handlers.
+
+    Each .mu file becomes a NomadNet page at /page/<filename>.
+    Template variables {node_name}, {mem_free}, {uptime} are substituted
+    at serve time.
+    """
+    import os
+
+    try:
+        files = os.listdir(pages_dir)
+    except OSError:
+        if DEBUG >= 1:
+            print("Pages directory not found:", pages_dir)
+        return 0
+
+    count = 0
+    for fname in files:
+        if not fname.endswith(".mu"):
+            continue
+
+        filepath = pages_dir + "/" + fname
+        page_path = "/page/" + fname
+
+        def fmt_mem(b):
+            if b >= 1048576:
+                return "%.1f MB" % (b / 1048576)
+            elif b >= 1024:
+                return "%.1f KB" % (b / 1024)
+            return str(b) + " B"
+
+        def fmt_uptime(s):
+            d, s = divmod(int(s), 86400)
+            h, s = divmod(s, 3600)
+            m, s = divmod(s, 60)
+            parts = []
+            if d: parts.append(str(d) + "d")
+            if h: parts.append(str(h) + "h")
+            if m: parts.append(str(m) + "m")
+            parts.append(str(s) + "s")
+            return " ".join(parts)
+
+        def make_handler(fpath):
+            def handler(path, data, request_id, link_id, remote_identity, requested_at):
+                try:
+                    with open(fpath, "rb") as f:
+                        page = f.read()
+                except OSError:
+                    return b">Page Not Found\n"
+                page = page.replace(b"{node_name}", NODE_NAME.encode("utf-8"))
+                try:
+                    page = page.replace(b"{mem_free}", fmt_mem(gc.mem_free()).encode("utf-8"))
+                except:
+                    page = page.replace(b"{mem_free}", b"?")
+                page = page.replace(b"{uptime}", fmt_uptime(time.time() - _boot_time).encode("utf-8"))
+                return page
+            return handler
+
+        dest.register_request_handler(
+            page_path,
+            response_generator=make_handler(filepath),
+            allow=dest.ALLOW_ALL,
+        )
+        count += 1
+        if DEBUG >= 2:
+            print("Loaded page:", page_path, "from", filepath)
+
+    if DEBUG >= 1:
+        print("Loaded", count, "page(s) from", pages_dir + "/")
+    return count
+
+
+def main():
+    import uasyncio as asyncio
+
+    ip = connect_wifi(WIFI_SSID, WIFI_PASS)
+    gc.collect()
+
+    from urns import Reticulum, Destination
+    from urns.log import LOG_NONE, LOG_NOTICE, LOG_DEBUG
+
+    log_map = {0: LOG_NONE, 1: LOG_NOTICE, 2: LOG_DEBUG}
+    rns = Reticulum(loglevel=log_map.get(DEBUG, LOG_NOTICE))
+    rns.config = CONFIG
+    gc.collect()
+
+    # Create NomadNet node destination: nomadnetwork.node
+    dest = Destination(
+        rns.identity, Destination.IN, Destination.SINGLE,
+        "nomadnetwork", "node",
+    )
+    dest.set_default_app_data(NODE_NAME.encode("utf-8"))
+    dest.accepts_links(True)
+
+    # Load pages from pages/ directory
+    load_pages(dest)
+
+    def on_link(link):
+        if DEBUG >= 1:
+            print("[Link] Established:", link)
+
+    dest.set_link_established_callback(on_link)
+    gc.collect()
+
+    rns.setup_interfaces()
+    gc.collect()
+
+    if DEBUG >= 1:
+        print("NomadNet node address:", dest.hexhash)
+        print("Free memory:", gc.mem_free(), "bytes")
+        print("Running... (Ctrl+C to stop)")
+
+    async def initial_announce():
+        await asyncio.sleep(0.5)
+        try:
+            dest.announce()
+            if DEBUG >= 1:
+                print("Announced as:", NODE_NAME)
+        except Exception as e:
+            if DEBUG >= 2:
+                print("Announce error:", e)
+        gc.collect()
+
+    async def reannounce_loop():
+        while True:
+            await asyncio.sleep(300)
+            try:
+                dest.announce()
+                if DEBUG >= 2:
+                    print("[Re-announced]")
+            except Exception as e:
+                if DEBUG >= 2:
+                    print("Re-announce error:", e)
+            gc.collect()
+
+    _original_run = rns.run
+
+    async def run_with_announce():
+        asyncio.create_task(initial_announce())
+        asyncio.create_task(reannounce_loop())
+        await _original_run()
+
+    try:
+        asyncio.run(run_with_announce())
+    except KeyboardInterrupt:
+        rns.shutdown()
+        if DEBUG >= 1:
+            print("Shutdown complete")
+
+
+main()

--- a/pages/index.mu
+++ b/pages/index.mu
@@ -1,0 +1,7 @@
+>Welcome to {node_name}
+
+This node is running `µReticulum` on an ESP32.
+
+>> Status
+  Free memory: {mem_free}
+  Uptime: {uptime}

--- a/urns/__init__.py
+++ b/urns/__init__.py
@@ -10,6 +10,7 @@ from .identity import Identity
 from .destination import Destination
 from .packet import Packet, PacketReceipt
 from .transport import Transport
+from .link import Link
 from . import lxmf
 from .reticulum import Reticulum
 

--- a/urns/destination.py
+++ b/urns/destination.py
@@ -235,11 +235,25 @@ class Destination:
             return self.identity.sign(message)
         return None
 
+    def register_request_handler(self, path, response_generator=None, allow=ALLOW_NONE):
+        path_hash = Identity.truncated_hash(path.encode("utf-8"))
+        self.request_handlers[path_hash] = {
+            "path": path,
+            "generator": response_generator,
+            "allow": allow,
+        }
+        log("Registered request handler for " + path, LOG_VERBOSE)
+
     def receive(self, packet):
         if packet.packet_type == const.PKT_LINKREQUEST:
             if self.accept_link_requests:
-                # Link handling will be implemented in Phase 4
-                pass
+                try:
+                    from .link import Link
+                    import gc; gc.collect()
+                    link = Link(self, packet)
+                    gc.collect()
+                except Exception as e:
+                    log("Link creation failed: " + str(e), LOG_ERROR)
         else:
             plaintext = self.decrypt(packet.data)
             if plaintext is not None:

--- a/urns/link.py
+++ b/urns/link.py
@@ -1,0 +1,295 @@
+# µReticulum Link
+# Server-side stateful encrypted link (Reticulum Link protocol)
+# Supports the 3-packet ECDH handshake + request/response RPC
+
+import struct
+import time
+from . import const
+from .log import log, LOG_VERBOSE, LOG_DEBUG, LOG_ERROR, LOG_NOTICE
+
+# Link key sizes
+ECPUBSIZE = 64       # X25519(32) + Ed25519(32)
+LINK_MTU_SIZE = 3    # Signalling bytes
+MTU_BYTEMASK = 0x1FFFFF
+MODE_BYTEMASK = 0xE0
+MODE_AES256_CBC = 0x01
+
+
+def _signalling_bytes(mtu, mode):
+    sv = (mtu & MTU_BYTEMASK) + (((mode << 5) & MODE_BYTEMASK) << 16)
+    return struct.pack(">I", sv)[1:]
+
+
+def _parse_signalling(data):
+    sv = struct.unpack(">I", b'\x00' + data)[0]
+    mtu = sv & MTU_BYTEMASK
+    mode = (sv >> 21) & 0x07
+    return mtu, mode
+
+
+class Link:
+    PENDING = 0x00
+    ACTIVE  = 0x01
+    CLOSED  = 0x02
+
+    KEEPALIVE_INTERVAL  = 360   # seconds
+    STALE_GRACE         = 720   # seconds
+    ESTABLISHMENT_TIMEOUT = 25  # seconds (extra margin for slow ECDH on ESP32)
+
+    def __init__(self, destination, packet):
+        from .identity import Identity
+        from .crypto import X25519PrivateKey, X25519PublicKey, Token, hkdf
+
+        if len(packet.data) < ECPUBSIZE:
+            raise ValueError("Link request too short: " + str(len(packet.data)))
+
+        # Parse peer keys from link request payload
+        peer_pub_bytes = packet.data[:32]
+        peer_sig_pub_bytes = packet.data[32:64]
+
+        # Parse signalling bytes if present (RNS 0.8+)
+        has_signalling = len(packet.data) > ECPUBSIZE
+        if has_signalling:
+            raw_sig_bytes = packet.data[ECPUBSIZE:ECPUBSIZE + LINK_MTU_SIZE]
+            link_mtu, link_mode = _parse_signalling(raw_sig_bytes)
+            self._signalling_bytes = _signalling_bytes(link_mtu, link_mode)
+        else:
+            self._signalling_bytes = b""
+
+        # Compute link_id: strip signalling bytes from hashable part
+        # (reference RNS: Link.link_id_from_lr_packet)
+        hashable_part = packet.get_hashable_part()
+        if has_signalling:
+            diff = len(packet.data) - ECPUBSIZE
+            hashable_part = hashable_part[:-diff]
+        self.link_id = Identity.full_hash(hashable_part)[:const.TRUNCATED_HASHLENGTH // 8]
+
+        self.hash = self.link_id
+        self.type = const.DEST_LINK
+        self.destination = destination
+        self.status = Link.PENDING
+        self.activated_at = None
+        self.last_activity = time.time()
+        self.last_proof_time = time.time()
+        self._callbacks_fired = False
+
+        log("Link request on " + destination.hexhash[:8] + " link_id=" + self.link_id.hex()[:8], LOG_VERBOSE)
+
+        # Generate ephemeral X25519 keypair for ECDH
+        import gc; gc.collect()
+        ephemeral_prv = X25519PrivateKey.generate()
+        gc.collect()
+        self._ephemeral_pub_bytes = ephemeral_prv.public_key().public_bytes()
+
+        # Compute shared secret via ECDH
+        peer_pub = X25519PublicKey.from_public_bytes(peer_pub_bytes)
+        shared_key = ephemeral_prv.exchange(peer_pub)
+        gc.collect()
+
+        # Derive link encryption key (64 bytes for AES-256 Token)
+        derived_key = hkdf(length=64, derive_from=shared_key, salt=self.link_id)
+        self._token = Token(derived_key)
+        gc.collect()
+
+        # Clean up ECDH key material
+        del ephemeral_prv, shared_key, derived_key, peer_pub
+        gc.collect()
+
+        # Register with Transport
+        from .transport import Transport
+        if len(Transport.active_links) >= const.MAX_ACTIVE_LINKS:
+            evicted = False
+            for i, l in enumerate(Transport.active_links):
+                if l.status == Link.CLOSED:
+                    Transport.active_links.pop(i)
+                    evicted = True
+                    break
+            if not evicted:
+                log("Active links table full, rejecting link", LOG_ERROR)
+                self.status = Link.CLOSED
+                return
+        Transport.active_links.append(self)
+
+        # Send link proof (packet 2 of handshake)
+        self._send_proof()
+
+        log("Link " + self.link_id.hex()[:8] + " pending (proof sent)", LOG_VERBOSE)
+
+    def _send_proof(self):
+        """Send link proof: signature(64) + ephemeral_pub(32) [+ signalling(3)]"""
+        import gc; gc.collect()
+
+        # Reference RNS prove(): signed_data = link_id + pub_bytes + sig_pub_bytes + signalling
+        # Where pub_bytes = server's ephemeral X25519 pub
+        # And sig_pub_bytes = destination's identity Ed25519 pub
+        # (client validates with destination.identity.get_public_key()[32:64])
+        signed_data = (self.link_id
+                       + self._ephemeral_pub_bytes
+                       + self.destination.identity.sig_pub_bytes
+                       + self._signalling_bytes)
+        signature = self.destination.identity.sign(signed_data)
+        gc.collect()
+
+        proof_data = signature + self._ephemeral_pub_bytes + self._signalling_bytes
+
+        from .packet import Packet
+        proof_packet = Packet(
+            self, proof_data,
+            const.PKT_PROOF,
+            context=const.CTX_LRPROOF,
+            create_receipt=False,
+        )
+        proof_packet.send()
+
+        # Clean up (no longer needed after proof)
+        del self._ephemeral_pub_bytes, self._signalling_bytes
+        gc.collect()
+
+    def receive(self, packet):
+        """Handle incoming data packet on this link."""
+        try:
+            plaintext = self._token.decrypt(packet.data)
+        except Exception as e:
+            log("Link " + self.link_id.hex()[:8] + " decrypt failed: " + str(e), LOG_DEBUG)
+            return
+
+        self.last_activity = time.time()
+
+        if packet.context == const.CTX_LRRTT:
+            self._handle_rtt(plaintext)
+        elif packet.context == const.CTX_REQUEST:
+            self._handle_request(plaintext, packet)
+        elif packet.context == const.CTX_KEEPALIVE:
+            log("Link " + self.link_id.hex()[:8] + " keepalive", LOG_DEBUG)
+        elif packet.context == const.CTX_LINKCLOSE:
+            log("Link " + self.link_id.hex()[:8] + " close received", LOG_VERBOSE)
+            self.status = Link.CLOSED
+        elif packet.context == const.CTX_LINKIDENTIFY:
+            log("Link " + self.link_id.hex()[:8] + " identify (not implemented)", LOG_DEBUG)
+        else:
+            log("Link " + self.link_id.hex()[:8] + " unhandled context=0x" + ("%02x" % packet.context), LOG_DEBUG)
+
+    def _handle_rtt(self, plaintext):
+        """RTT packet marks link as ACTIVE (packet 3 of handshake)."""
+        if self.status == Link.PENDING:
+            self.status = Link.ACTIVE
+            self.activated_at = time.time()
+            log("Link " + self.link_id.hex()[:8] + " ACTIVE", LOG_NOTICE)
+
+            if not self._callbacks_fired and self.destination.link_established_callback:
+                self._callbacks_fired = True
+                try:
+                    self.destination.link_established_callback(self)
+                except Exception as e:
+                    log("Link established callback error: " + str(e), LOG_ERROR)
+
+    def _handle_request(self, plaintext, packet):
+        """Handle incoming request on established link."""
+        if self.status != Link.ACTIVE:
+            log("Link " + self.link_id.hex()[:8] + " request on non-active link, ignoring", LOG_DEBUG)
+            return
+
+        from . import umsgpack
+
+        try:
+            request_data = umsgpack.unpackb(plaintext)
+        except Exception as e:
+            log("Link " + self.link_id.hex()[:8] + " request unpack error: " + str(e), LOG_DEBUG)
+            return
+
+        if not isinstance(request_data, list) or len(request_data) < 2:
+            log("Link " + self.link_id.hex()[:8] + " malformed request", LOG_DEBUG)
+            return
+
+        # Request format: [timestamp, path_hash, data]
+        requested_at = request_data[0]
+        path_hash = request_data[1]
+        req_data = request_data[2] if len(request_data) > 2 else None
+
+        # Compute request_id from the packet's truncated hash
+        request_id = packet.getTruncatedHash()
+
+        log("Link " + self.link_id.hex()[:8] + " request path_hash=" + path_hash.hex()[:8], LOG_DEBUG)
+
+        # Look up handler by path_hash
+        handler_entry = self.destination.request_handlers.get(path_hash)
+        if handler_entry is None:
+            log("Link " + self.link_id.hex()[:8] + " no handler for path", LOG_DEBUG)
+            return
+
+        from .destination import Destination
+        if handler_entry["allow"] == Destination.ALLOW_NONE:
+            log("Link " + self.link_id.hex()[:8] + " request denied by policy", LOG_DEBUG)
+            return
+
+        # Call the response generator
+        try:
+            response = handler_entry["generator"](
+                path=handler_entry.get("path", ""),
+                data=req_data,
+                request_id=request_id,
+                link_id=self.link_id,
+                remote_identity=None,
+                requested_at=requested_at,
+            )
+        except Exception as e:
+            log("Link " + self.link_id.hex()[:8] + " handler error: " + str(e), LOG_ERROR)
+            return
+
+        if response is None:
+            return
+
+        # Pack response: [request_id, response_data]
+        response_packed = umsgpack.packb([request_id, response])
+
+        # Max plaintext for a single link data packet:
+        # MTU(500) - HDR_1(19) - IV(16) - max_PKCS7(16) - HMAC(32) = 417
+        if len(response_packed) > 417:
+            log("Link " + self.link_id.hex()[:8] + " response too large (" + str(len(response_packed)) + "B), needs Resource (not implemented)", LOG_ERROR)
+            return
+
+        self.send(response_packed, const.CTX_RESPONSE)
+        log("Link " + self.link_id.hex()[:8] + " response sent (" + str(len(response_packed)) + "B)", LOG_DEBUG)
+
+    def send(self, data, context=const.CTX_NONE):
+        """Send encrypted data on this link."""
+        ciphertext = self._token.encrypt(data)
+
+        from .packet import Packet, LinkDestination
+        packet = Packet(
+            LinkDestination(self.link_id),
+            ciphertext,
+            const.PKT_DATA,
+            context=context,
+            create_receipt=False,
+        )
+        packet.send()
+
+    def check_keepalive(self):
+        """Check link staleness and send keepalive if needed."""
+        now = time.time()
+
+        # Check establishment timeout for pending links
+        if self.status == Link.PENDING:
+            if now - self.last_proof_time > Link.ESTABLISHMENT_TIMEOUT:
+                log("Link " + self.link_id.hex()[:8] + " establishment timeout", LOG_VERBOSE)
+                self.status = Link.CLOSED
+            return
+
+        if self.status != Link.ACTIVE:
+            return
+
+        # Check stale grace period
+        if now - self.last_activity > Link.STALE_GRACE:
+            log("Link " + self.link_id.hex()[:8] + " stale, closing", LOG_VERBOSE)
+            self.teardown()
+
+    def teardown(self):
+        """Close this link."""
+        if self.status != Link.CLOSED:
+            self.status = Link.CLOSED
+            log("Link " + self.link_id.hex()[:8] + " torn down", LOG_VERBOSE)
+
+    def __repr__(self):
+        states = {0: "PENDING", 1: "ACTIVE", 2: "CLOSED"}
+        return "<Link:" + self.link_id.hex()[:8] + " " + states.get(self.status, "?") + ">"

--- a/urns/packet.py
+++ b/urns/packet.py
@@ -272,6 +272,17 @@ class ProofDestination:
         return plaintext
 
 
+class LinkDestination:
+    """Pseudo-destination for packets addressed to a link_id."""
+    def __init__(self, link_id):
+        self.hash = link_id
+        self.link_id = link_id
+        self.type = const.DEST_LINK
+
+    def encrypt(self, plaintext):
+        return plaintext
+
+
 class PacketReceipt:
     FAILED    = 0x00
     SENT      = 0x01

--- a/urns/transport.py
+++ b/urns/transport.py
@@ -309,6 +309,16 @@ class Transport:
                     if l in Transport.pending_links:
                         Transport.pending_links.remove(l)
 
+                # Check active link keepalives and stale cleanup
+                closed_links = []
+                for link in Transport.active_links:
+                    link.check_keepalive()
+                    if link.status == 0x02:  # CLOSED
+                        closed_links.append(link)
+                for l in closed_links:
+                    if l in Transport.active_links:
+                        Transport.active_links.remove(l)
+
                 import gc
                 gc.collect()
 


### PR DESCRIPTION
 Summary

  - Implement server-side Reticulum Link support — full 3-packet ECDH handshake (X25519 key exchange, Ed25519-signed proof, RTT activation) with AES-256-CBC encrypted request/response
  RPC
  - Serve NomadNet micron-format pages from a pages/ directory with template variable substitution ({node_name}, {mem_free}, {uptime})
  - Add TCP client interface, transport mode, and NomadNet page serving sections to README

  What's new

  urns/link.py (new) — Server-side Link class handling the complete link lifecycle: request parsing, ephemeral ECDH key exchange, HKDF key derivation, link proof signing, RTT
  activation, encrypted request/response dispatch, keepalive, and stale link teardown. Supports RNS 0.8+ signalling bytes. ~350 bytes RAM per link, up to 4 concurrent.

  example_nomadnet_node.py (new) — NomadNet page-serving node example. Announces as nomadnetwork.node, auto-discovers .mu page files from pages/ directory, supports template variables
  with human-readable memory and uptime formatting.

  pages/index.mu (new) — Example micron-format status page.

  urns/destination.py — Added register_request_handler() for path-based RPC handlers. Wired link request acceptance into receive().

  urns/packet.py — Added LinkDestination pseudo-destination for link-addressed packets.

  urns/transport.py — Added active link keepalive checks and stale link cleanup to the async job loop.

  urns/__init__.py — Export Link class.

  README.md — Expanded NomadNet section with setup instructions, page file format, template variables, ~350 byte page size limit, link handshake diagram, and RAM/concurrency details.

  Page size limit

  Pages must fit in a single encrypted link packet. After AES-256-CBC IV (16B), PKCS7 padding (up to 16B), HMAC-SHA256 (32B), and packet headers (19B), the maximum page content is ~350
   bytes. Larger pages require Resource transfer (not yet implemented).

  Tested

  - ESP32-S3 over TCP transport server — link handshake, page request/response confirmed working with NomadNet and MeshChat
  - Multiple link establishments, concurrent links, stale link cleanup
  - Template variable substitution with human-readable formatting