### PR TITLE
  LoRa RNode split-packet protocol + TCP transport path routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Requires MicroPython 1.22+. Should also work on other ESP32-S3 boards and Raspbe
 - **NomadNet Page Serving** — Serve micron-format pages to NomadNet clients over Reticulum Links. Full ECDH link handshake with request/response RPC for small pages (< ~350 bytes).
 - **Transport Mode** — Blind flood forwarding between interfaces. Bridge WiFi and LoRa so packets from one interface are relayed to all others.
 - **UDP Interface** — WiFi networking with auto-detected subnet broadcast. Non-blocking async I/O with ESP32 socket recovery.
-- **TCP Client Interface** — HDLC-framed TCP connection to remote RNS transport servers. Enables long-range connectivity beyond the local LAN.
-- **SX1262 SPI LoRa Interface** — Native SPI control of SX1262 LoRa radios (e.g. Seeed XIAO ESP32S3 + Wio-SX1262). Interoperates with RNode (SX1276/SX1278) and reference Reticulum over LoRa — bidirectional LXMF messaging, announces, and delivery proofs all work. Built-in fragmentation for Reticulum's 500-byte MTU over 255-byte LoRa packets. RSSI/SNR reporting.
+- **TCP Client Interface** — HDLC-framed TCP connection to remote RNS transport servers. Automatic transport path routing: learns relay paths from HDR_2 announces and wraps outbound DATA packets for correct delivery through the transport server. Enables long-range connectivity beyond the local LAN.
+- **SX1262 SPI LoRa Interface** — Native SPI control of SX1262 LoRa radios (e.g. Seeed XIAO ESP32S3 + Wio-SX1262). Implements RNode-compatible split-packet framing: packets up to 500 bytes are transparently split across two 255-byte LoRa frames, matching the exact protocol used by RNode firmware. Full interop with RNode (SX1276/SX1278) — bidirectional LXMF messaging, announces, and delivery proofs all work. RSSI/SNR reporting.
 - **Serial Interface** — HDLC-framed UART for RNode, LoRa radios, packet radio TNCs, or ESP32-to-ESP32 links.
 - **Persistent Identity** — Keys and known destinations survive reboots. JSON configuration.
 
@@ -96,7 +96,7 @@ ureticulum/
 │   │   ├── udp.py           # WiFi UDP with broadcast discovery
 │   │   ├── tcp.py           # HDLC-framed TCP client (for RNS transport servers)
 │   │   ├── serial.py        # HDLC-framed UART (RNode, LoRa, ESP-to-ESP)
-│   │   └── lora.py          # SX1262 SPI LoRa with fragmentation
+│   │   └── lora.py          # SX1262 SPI LoRa with RNode-compatible split framing
 │   └── crypto/
 │       ├── x25519.py        # X25519 ECDH key exchange
 │       ├── ed25519.py       # Ed25519 signing/verification
@@ -295,7 +295,7 @@ mpremote mip install lora-sx126x
 - `dio2_rf_sw`: `true` — SX1262 internally drives DIO2 as RF switch (default, correct for Wio-SX1262)
 - `dio3_tcxo_millivolts`: `1800` for Wio-SX1262 TCXO (default). Set `null` to disable for modules with a crystal oscillator instead of TCXO.
 
-**Fragmentation:** The SX1262 has a 255-byte packet limit while Reticulum's MTU is 500 bytes. The interface automatically fragments and reassembles packets — no configuration needed.
+**Split-packet framing:** The SX1262 has a 255-byte packet limit while Reticulum's MTU is 500 bytes. The interface uses RNode-compatible split-packet framing: a 1-byte header is prepended to every LoRa frame (random 4-bit sequence in the upper nibble, FLAG_SPLIT in bit 0). Packets up to 254 bytes are sent as a single frame; larger packets are split across exactly two frames with matching sequence numbers — the same protocol used by RNode firmware. No configuration needed.
 
 ### TCP Client Interface
 
@@ -406,8 +406,8 @@ Tested and confirmed working with:
 - **NomadNet** — Peer discovery, LXMF messaging, page serving over Links
 - **Reference Reticulum** (Python) — Wire-compatible packets, announces, encryption, link handshake
 - **Reference LXMF** — Cross-validated message packing/unpacking, signature verification
-- **RNode** (SX1276/SX1278) — Bidirectional LoRa: announces, encrypted LXMF messages, delivery proofs. Tested with Heltec Wireless Stick Lite V1 running RNode firmware on 868 MHz
-- **RNS Transport Servers** — TCP client connectivity to remote transport hubs
+- **RNode** (SX1276/SX1278) — Bidirectional LoRa: announces, encrypted LXMF messages, delivery proofs. Full split-packet support for the complete Reticulum 500-byte MTU. Tested with Heltec Wireless Stick Lite V1 running RNode firmware on 868 MHz
+- **RNS Transport Servers** — TCP client connectivity to remote transport hubs. Automatic path learning from announces: outbound DATA packets are wrapped as HDR_2 TRANSPORT for correct relay routing
 
 ## ESP32 Socket Workarounds
 
@@ -420,15 +420,33 @@ The UDP interface includes several workarounds for ESP32 MicroPython lwIP quirks
 - **WiFi power management disabled** — `wlan.config(pm=0)` is required to receive broadcast UDP packets.
 - **AP_IF deactivated** — dual-interface mode routes broadcast packets to AP instead of STA, preventing UDP broadcast reception.
 
-## SX1262 LoRa Workarounds
+## SX1262 LoRa — RNode Split-Packet Protocol
 
-The LoRa interface includes workarounds for a FIFO buffer offset issue in the `lora-sx126x` driver on ESP32-S3 + Wio-SX1262 hardware:
+The LoRa interface implements the same split-packet framing as [RNode firmware](https://github.com/markqvist/RNode_Firmware), enabling transparent interop with RNode devices and support for Reticulum's full 500-byte MTU over LoRa's 255-byte frame limit.
 
-- **RX byte stripping** — The SX1262 receive path prepends one spurious byte (a FIFO status/offset artifact) before the actual LoRa payload. This byte varies between receptions of the same packet while bytes 1+ remain stable. The interface strips this leading byte before passing data to the Reticulum stack.
-- **TX byte prepending** — Symmetrically, the transmit path loses the first byte of data written to the FIFO. A dummy `0x00` byte is prepended before sending so the actual packet data starts at the correct offset.
-- **IFAC filtering** — Packets with bit 7 set in the flags byte (IFAC-tagged) are dropped on receipt, since µReticulum does not implement Interface Access Codes. This matches reference Reticulum behavior for non-IFAC interfaces.
+### How it works
 
-The driver source code appears correct (it uses `n_read=1` to consume the SX1262 NOP byte), so this is likely a platform-specific SPI timing issue on ESP32-S3 rather than a driver bug.
+Every LoRa frame carries a **1-byte RNode header**:
+
+| Bits | Field | Description |
+|------|-------|-------------|
+| 7–4 | Sequence | Random 4-bit value for matching split halves |
+| 0 | FLAG_SPLIT | Set when packet is split across 2 frames |
+
+- **Single frame** (data ≤ 254 bytes): `[header] [data]` — max 255 bytes
+- **Split packet** (data 255–508 bytes): Two frames with the same header byte (same sequence + FLAG_SPLIT), sent back-to-back:
+  - Frame 1: `[header] [first 254 bytes]` = 255 bytes
+  - Frame 2: `[header] [remaining bytes]`
+
+The receiver matches split frames by sequence number and reassembles them into a complete Reticulum packet. Stale fragments are discarded after 15 seconds.
+
+### Note on the `lora-sx126x` driver
+
+The `lora-sx126x` MicroPython driver (`mpremote mip install lora-sx126x`) sends and receives bytes faithfully — the RNode header byte is the first byte returned by `poll_recv()` on RX and the first byte written by `send()` on TX. No FIFO offset workarounds are needed.
+
+### IFAC filtering
+
+Packets with bit 7 set in the Reticulum flags byte (IFAC-tagged) are dropped on receipt, since µReticulum does not implement Interface Access Codes. This matches reference Reticulum behavior for non-IFAC interfaces.
 
 ## Limitations
 

--- a/example_node.py
+++ b/example_node.py
@@ -14,10 +14,14 @@ from config import WIFI_SSID, WIFI_PASS, NODE_NAME, DEBUG, CONFIG
 import gc
 gc.collect()
 
-from machine import Pin
+from machine import Pin, SoftI2C
 import neopixel
+import sensors.bme280 as bme280
 
-led = neopixel.NeoPixel(Pin(21),1)
+i2c = SoftI2C(scl=Pin(6), sda=Pin(5),freq=100000)
+bme = bme280.BME280(i2c=i2c)
+
+#led = neopixel.NeoPixel(Pin(21),1)
 colors={"green":(255,0,0),
         "red":(0,255,0),
         "blue":(0,0,255),
@@ -99,8 +103,13 @@ def setup_node(rns, node_name):
         content = message.content_as_string() or "(binary)"
 
         if content.lower() in colors.keys():
-            led[0]=colors[content.lower()]
-            led.write()
+            #led[0]=colors[content.lower()]
+            #led.write()
+            pass
+
+        if "sensor" in content.lower():
+            t, p, h = bme.values
+            content = "Temperature: {}, Pressure: {}, Humidity: {}".format(t, p, h)
             
         if DEBUG >= 1:
             print()
@@ -114,6 +123,7 @@ def setup_node(rns, node_name):
             print("=" * 40)
 
         # Queue async echo reply (non-blocking)
+        #asyncio.create_task(send_echo_reply(router, message.source_hash, content))
         asyncio.create_task(send_echo_reply(router, message.source_hash, content))
         gc.collect()
 

--- a/pages/index.mu
+++ b/pages/index.mu
@@ -5,3 +5,6 @@ This node is running `µReticulum` on an ESP32.
 >> Status
   Free memory: {mem_free}
   Uptime: {uptime}
+
+>> Sensor data
+  {sensor}

--- a/sensors/bme280.py
+++ b/sensors/bme280.py
@@ -1,0 +1,262 @@
+# Updated 2018 and 2020
+# This module is based on the below cited resources, which are all
+# based on the documentation as provided in the Bosch Data Sheet and
+# the sample implementation provided therein.
+#
+# Final Document: BST-BME280-DS002-15
+#
+# Authors: Paul Cunnane 2016, Peter Dahlebrg 2016
+#
+# This module borrows from the Adafruit BME280 Python library. Original
+# Copyright notices are reproduced below.
+#
+# Those libraries were written for the Raspberry Pi. This modification is
+# intended for the MicroPython and esp8266 boards.
+#
+# Copyright (c) 2014 Adafruit Industries
+# Author: Tony DiCola
+#
+# Based on the BMP280 driver with BME280 changes provided by
+# David J Taylor, Edinburgh (www.satsignal.eu)
+#
+# Based on Adafruit_I2C.py created by Kevin Townsend.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import time
+from ustruct import unpack, unpack_from
+from array import array
+
+# BME280 default address.
+BME280_I2CADDR = 0x76
+
+# Operating Modes
+BME280_OSAMPLE_1 = 1
+BME280_OSAMPLE_2 = 2
+BME280_OSAMPLE_4 = 3
+BME280_OSAMPLE_8 = 4
+BME280_OSAMPLE_16 = 5
+
+BME280_REGISTER_CONTROL_HUM = 0xF2
+BME280_REGISTER_STATUS = 0xF3
+BME280_REGISTER_CONTROL = 0xF4
+
+MODE_SLEEP = const(0)
+MODE_FORCED = const(1)
+MODE_NORMAL = const(3)
+
+BME280_TIMEOUT = const(100)  # about 1 second timeout
+
+class BME280:
+
+    def __init__(self,
+                 mode=BME280_OSAMPLE_8,
+                 address=BME280_I2CADDR,
+                 i2c=None,
+                 **kwargs):
+        # Check that mode is valid.
+        if type(mode) is tuple and len(mode) == 3:
+            self._mode_hum, self._mode_temp, self._mode_press = mode
+        elif type(mode) == int:
+            self._mode_hum, self._mode_temp, self._mode_press = mode, mode, mode
+        else:
+            raise ValueError("Wrong type for the mode parameter, must be int or a 3 element tuple")
+
+        for mode in (self._mode_hum, self._mode_temp, self._mode_press):
+            if mode not in [BME280_OSAMPLE_1, BME280_OSAMPLE_2, BME280_OSAMPLE_4,
+                            BME280_OSAMPLE_8, BME280_OSAMPLE_16]:
+                raise ValueError(
+                    'Unexpected mode value {0}. Set mode to one of '
+                    'BME280_OSAMPLE_1, BME280_OSAMPLE_2, BME280_OSAMPLE_4, '
+                    'BME280_OSAMPLE_8 or BME280_OSAMPLE_16'.format(mode))
+
+        self.address = address
+        if i2c is None:
+            raise ValueError('An I2C object is required.')
+        self.i2c = i2c
+        self.__sealevel = 101325
+
+        # load calibration data
+        dig_88_a1 = self.i2c.readfrom_mem(self.address, 0x88, 26)
+        dig_e1_e7 = self.i2c.readfrom_mem(self.address, 0xE1, 7)
+
+        self.dig_T1, self.dig_T2, self.dig_T3, self.dig_P1, \
+            self.dig_P2, self.dig_P3, self.dig_P4, self.dig_P5, \
+            self.dig_P6, self.dig_P7, self.dig_P8, self.dig_P9, \
+            _, self.dig_H1 = unpack("<HhhHhhhhhhhhBB", dig_88_a1)
+
+        self.dig_H2, self.dig_H3, self.dig_H4,\
+            self.dig_H5, self.dig_H6 = unpack("<hBbhb", dig_e1_e7)
+        # unfold H4, H5, keeping care of a potential sign
+        self.dig_H4 = (self.dig_H4 * 16) + (self.dig_H5 & 0xF)
+        self.dig_H5 //= 16
+
+        # temporary data holders which stay allocated
+        self._l1_barray = bytearray(1)
+        self._l8_barray = bytearray(8)
+        self._l3_resultarray = array("i", [0, 0, 0])
+
+        self._l1_barray[0] = self._mode_temp << 5 | self._mode_press << 2 | MODE_SLEEP
+        self.i2c.writeto_mem(self.address, BME280_REGISTER_CONTROL,
+                             self._l1_barray)
+        self.t_fine = 0
+
+    def read_raw_data(self, result):
+        """ Reads the raw (uncompensated) data from the sensor.
+
+            Args:
+                result: array of length 3 or alike where the result will be
+                stored, in temperature, pressure, humidity order
+            Returns:
+                None
+        """
+
+        self._l1_barray[0] = self._mode_hum
+        self.i2c.writeto_mem(self.address, BME280_REGISTER_CONTROL_HUM,
+                             self._l1_barray)
+        self._l1_barray[0] = self._mode_temp << 5 | self._mode_press << 2 | MODE_FORCED
+        self.i2c.writeto_mem(self.address, BME280_REGISTER_CONTROL,
+                             self._l1_barray)
+
+        # wait up to about 5 ms for the conversion to start
+        for _ in range(5):
+            if self.i2c.readfrom_mem(self.address, BME280_REGISTER_STATUS, 1)[0] & 0x08:
+                break;  # The conversion is started.
+            time.sleep_ms(1)  # still not busy
+        # Wait for conversion to complete
+        for _ in range(BME280_TIMEOUT):
+            if self.i2c.readfrom_mem(self.address, BME280_REGISTER_STATUS, 1)[0] & 0x08:
+                time.sleep_ms(10)  # still busy
+            else:
+                break  # Sensor ready
+        else:
+            raise RuntimeError("Sensor BME280 not ready")
+
+        # burst readout from 0xF7 to 0xFE, recommended by datasheet
+        self.i2c.readfrom_mem_into(self.address, 0xF7, self._l8_barray)
+        readout = self._l8_barray
+        # pressure(0xF7): ((msb << 16) | (lsb << 8) | xlsb) >> 4
+        raw_press = ((readout[0] << 16) | (readout[1] << 8) | readout[2]) >> 4
+        # temperature(0xFA): ((msb << 16) | (lsb << 8) | xlsb) >> 4
+        raw_temp = ((readout[3] << 16) | (readout[4] << 8) | readout[5]) >> 4
+        # humidity(0xFD): (msb << 8) | lsb
+        raw_hum = (readout[6] << 8) | readout[7]
+
+        result[0] = raw_temp
+        result[1] = raw_press
+        result[2] = raw_hum
+
+    def read_compensated_data(self, result=None):
+        """ Reads the data from the sensor and returns the compensated data.
+
+            Args:
+                result: array of length 3 or alike where the result will be
+                stored, in temperature, pressure, humidity order. You may use
+                this to read out the sensor without allocating heap memory
+
+            Returns:
+                array with temperature, pressure, humidity. Will be the one
+                from the result parameter if not None
+        """
+        self.read_raw_data(self._l3_resultarray)
+        raw_temp, raw_press, raw_hum = self._l3_resultarray
+        # temperature
+        var1 = (raw_temp/16384.0 - self.dig_T1/1024.0) * self.dig_T2
+        var2 = raw_temp/131072.0 - self.dig_T1/8192.0
+        var2 = var2 * var2 * self.dig_T3
+        self.t_fine = int(var1 + var2)
+        temp = (var1 + var2) / 5120.0
+        temp = max(-40, min(85, temp))
+
+        # pressure
+        var1 = (self.t_fine/2.0) - 64000.0
+        var2 = var1 * var1 * self.dig_P6 / 32768.0 + var1 * self.dig_P5 * 2.0
+        var2 = (var2 / 4.0) + (self.dig_P4 * 65536.0)
+        var1 = (self.dig_P3 * var1 * var1 / 524288.0 + self.dig_P2 * var1) / 524288.0
+        var1 = (1.0 + var1 / 32768.0) * self.dig_P1
+        if (var1 == 0.0):
+            pressure = 30000  # avoid exception caused by division by zero
+        else:
+            p = ((1048576.0 - raw_press) - (var2 / 4096.0)) * 6250.0 / var1
+            var1 = self.dig_P9 * p * p / 2147483648.0
+            var2 = p * self.dig_P8 / 32768.0
+            pressure = p + (var1 + var2 + self.dig_P7) / 16.0
+            pressure = max(30000, min(110000, pressure))
+
+        # humidity
+        h = (self.t_fine - 76800.0)
+        h = ((raw_hum - (self.dig_H4 * 64.0 + self.dig_H5 / 16384.0 * h)) *
+             (self.dig_H2 / 65536.0 * (1.0 + self.dig_H6 / 67108864.0 * h *
+                                       (1.0 + self.dig_H3 / 67108864.0 * h))))
+        humidity = h * (1.0 - self.dig_H1 * h / 524288.0)
+        if (humidity < 0):
+            humidity = 0
+        if (humidity > 100):
+            humidity = 100.0
+
+        if result:
+            result[0] = temp
+            result[1] = pressure
+            result[2] = humidity
+            return result
+
+        return array("f", (temp, pressure, humidity))
+
+    @property
+    def sealevel(self):
+        return self.__sealevel
+
+    @sealevel.setter
+    def sealevel(self, value):
+        if 30000 < value < 120000:  # just ensure some reasonable value
+            self.__sealevel = value
+
+    @property
+    def altitude(self):
+        '''
+        Altitude in m.
+        '''
+        from math import pow
+        try:
+            p = 44330 * (1.0 - pow(self.read_compensated_data()[1] /
+                                   self.__sealevel, 0.1903))
+        except:
+            p = 0.0
+        return p
+
+    @property
+    def dew_point(self):
+        """
+        Compute the dew point temperature for the current Temperature
+        and Humidity measured pair
+        """
+        from math import log
+        t, p, h = self.read_compensated_data()
+        h = (log(h, 10) - 2) / 0.4343 + (17.62 * t) / (243.12 + t)
+        return 243.12 * h / (17.62 - h)
+
+    @property
+    def values(self):
+        """ human readable values """
+
+        t, p, h = self.read_compensated_data()
+
+        return ("{:.2f}C".format(t), "{:.2f}hPa".format(p/100),
+                "{:.2f}%".format(h))

--- a/urns/interfaces/lora.py
+++ b/urns/interfaces/lora.py
@@ -2,25 +2,23 @@
 # Direct SPI control via micropython-lib lora-sx126x driver.
 # Install: mpremote mip install lora-sx126x
 #
-# Fragmentation: SX1262 max packet = 255 bytes, Reticulum MTU = 500.
-# 1-byte header per LoRa frame: bits 7-6 = type, bits 5-0 = seq (0-63).
+# RNode-compatible framing: 1-byte header per LoRa frame.
+# Upper nibble = random sequence, bit 0 = FLAG_SPLIT.
+# Packets > 254 bytes are split across exactly 2 frames (max 508B).
+# Compatible with RNode firmware and reference Reticulum.
 
+import os
 import gc
 import time
 from . import Interface
 from ..log import log, LOG_VERBOSE, LOG_DEBUG, LOG_ERROR, LOG_NOTICE
 
-# Fragment types (upper 2 bits)
-_SINGLE = const(0x00)
-_FIRST  = const(0x40)
-_MIDDLE = const(0x80)
-_LAST   = const(0xC0)
+# RNode header constants (matches RNode_Firmware Framing.h)
+_FLAG_SPLIT = const(0x01)
+_SEQ_MASK   = const(0xF0)
 
-_TYPE_MASK = const(0xC0)
-_SEQ_MASK  = const(0x3F)
-
-# Max payload per LoRa frame (255 - 1 byte header)
-_FRAG_PAYLOAD = const(254)
+# Max payload per LoRa frame (255 - 1 byte RNode header)
+_FRAME_PAYLOAD = const(254)
 
 # Reassembly timeout (seconds)
 _REASM_TIMEOUT = const(15)
@@ -60,15 +58,7 @@ class LoRaInterface(Interface):
 
         self._modem = None
 
-        # Fragmentation: disabled by default for RNode interop.
-        # RNode sends raw Reticulum packets with no fragment header.
-        # Enable only for SX1262-to-SX1262 links needing MTU > 255.
-        self._fragment_en = config.get("fragment", False)
-
-        # Fragment TX state
-        self._seq_counter = 0
-
-        # Reassembly RX state
+        # Split-packet reassembly state
         self._reasm_buf = None
         self._reasm_seq = None
         self._reasm_time = 0
@@ -119,101 +109,36 @@ class LoRaInterface(Interface):
         self._modem.rx_crc_error = True  # Surface CRC-failed packets for diagnostics
         self._modem.start_recv(continuous=True)
 
-    def _next_seq(self):
-        seq = self._seq_counter & _SEQ_MASK
-        self._seq_counter = (self._seq_counter + 1) & _SEQ_MASK
-        return seq
-
-    def _fragment(self, data):
-        """Split data into LoRa-sized frames with 1-byte fragment header."""
-        if len(data) <= _FRAG_PAYLOAD:
-            seq = self._next_seq()
-            return [bytes([_SINGLE | seq]) + data]
-
-        seq = self._next_seq()
-        frames = []
-        offset = 0
-
-        # First fragment
-        frames.append(bytes([_FIRST | seq]) + data[offset:offset + _FRAG_PAYLOAD])
-        offset += _FRAG_PAYLOAD
-
-        # Middle fragments (not needed at MTU=500, but correct for any size)
-        while offset + _FRAG_PAYLOAD < len(data):
-            frames.append(bytes([_MIDDLE | seq]) + data[offset:offset + _FRAG_PAYLOAD])
-            offset += _FRAG_PAYLOAD
-
-        # Last fragment
-        frames.append(bytes([_LAST | seq]) + data[offset:])
-        return frames
-
-    def _reassemble(self, raw):
-        """Process a received LoRa frame. Returns complete packet or None."""
-        if len(raw) < 2:
-            return None
-
-        hdr = raw[0]
-        ftype = hdr & _TYPE_MASK
-        seq = hdr & _SEQ_MASK
-        payload = raw[1:]
-
-        if ftype == _SINGLE:
-            return payload
-
-        now = time.time()
-
-        if ftype == _FIRST:
-            self._reasm_buf = bytearray(payload)
-            self._reasm_seq = seq
-            self._reasm_time = now
-            return None
-
-        # MIDDLE or LAST — must match current reassembly
-        if self._reasm_buf is None or self._reasm_seq != seq:
-            self._reasm_buf = None
-            return None
-
-        if now - self._reasm_time > _REASM_TIMEOUT:
-            log("LoRa reassembly timeout", LOG_DEBUG)
-            self._reasm_buf = None
-            return None
-
-        self._reasm_buf.extend(payload)
-
-        if ftype == _LAST:
-            result = bytes(self._reasm_buf)
-            self._reasm_buf = None
-            self._reasm_seq = None
-            return result
-
-        # MIDDLE — keep accumulating
-        return None
-
     def process_outgoing(self, data):
         if not self.online or not self._modem:
             return False
 
         try:
-            # Prepend dummy byte to compensate for SX1262 FIFO
-            # write-offset artifact (symmetric with RX strip).
-            data = b'\x00' + data
+            if len(data) > 2 * _FRAME_PAYLOAD:
+                log("LoRa drop: " + str(len(data)) + "B exceeds " + str(2 * _FRAME_PAYLOAD), LOG_DEBUG)
+                return False
 
-            if self._fragment_en:
-                frames = self._fragment(data)
-                for frame in frames:
-                    self._modem.send(frame)
-                log("LoRa sent " + str(len(data) - 1) + "B in "
-                    + str(len(frames)) + " frame(s)", LOG_DEBUG)
+            # RNode-compatible header: random seq in upper nibble.
+            # The SX1262 driver sends all bytes faithfully — no FIFO
+            # offset bug.  The old b'\x00' dummy byte was actually
+            # being sent over the air as a valid RNode header (seq=0,
+            # no split).  Now we send a proper header instead.
+            header = os.urandom(1)[0] & _SEQ_MASK
+
+            if len(data) > _FRAME_PAYLOAD:
+                # Split into 2 frames (RNode protocol)
+                header |= _FLAG_SPLIT
+                hdr = bytes([header])
+                self._modem.send(hdr + data[:_FRAME_PAYLOAD])
+                self._modem.send(hdr + data[_FRAME_PAYLOAD:])
+                log("LoRa TX " + str(len(data)) + "B split seq=" + hex(header >> 4), LOG_DEBUG)
             else:
-                if len(data) > 256:
-                    log("LoRa drop: " + str(len(data) - 1) + "B exceeds 255 (fragment=False)", LOG_ERROR)
-                    return False
-                self._modem.send(data)
-                log("LoRa sent " + str(len(data) - 1) + "B raw", LOG_DEBUG)
-                log("LoRa TX raw[0:20]=" + data[1:21].hex(), LOG_DEBUG)
+                # Single frame
+                self._modem.send(bytes([header]) + data)
+                log("LoRa TX " + str(len(data)) + "B", LOG_DEBUG)
 
             self._modem.start_recv(continuous=True)
-            self.txb += len(data) - 1
+            self.txb += len(data)
             self.tx += 1
             self._last_activity = time.time()
             return True
@@ -228,8 +153,7 @@ class LoRaInterface(Interface):
     async def poll_loop(self):
         import uasyncio as asyncio
 
-        log("LoRa poll loop started for " + self.name
-            + " fragment=" + str(self._fragment_en), LOG_NOTICE)
+        log("LoRa poll loop started for " + self.name, LOG_NOTICE)
 
         _last_gc = time.time()
         _last_diag = time.time()
@@ -255,11 +179,10 @@ class LoRaInterface(Interface):
                     _rx_pkt_count = 0
                     _last_diag = now
 
-                # Stale reassembly cleanup (only when fragmentation enabled)
-                if (self._fragment_en
-                        and self._reasm_buf is not None
+                # Stale reassembly cleanup
+                if (self._reasm_buf is not None
                         and now - self._reasm_time > _REASM_TIMEOUT):
-                    log("LoRa discarding stale fragment", LOG_DEBUG)
+                    log("LoRa discarding stale split fragment", LOG_DEBUG)
                     self._reasm_buf = None
                     self._reasm_seq = None
 
@@ -282,27 +205,47 @@ class LoRaInterface(Interface):
                     log("LoRa RX raw " + str(len(raw)) + "B"
                         + " RSSI=" + str(getattr(rx, "rssi", "?"))
                         + " SNR=" + str(getattr(rx, "snr", "?")), LOG_DEBUG)
-                    log("LoRa RX hex[0:20]=" + raw[:20].hex(), LOG_DEBUG)
 
                     if hasattr(rx, "valid_crc") and not rx.valid_crc:
                         log("LoRa CRC fail, discarding", LOG_DEBUG)
                         await asyncio.sleep(0.05)
                         continue
 
-                    # The lora-sx126x driver prepends one spurious byte
-                    # when reading from the SX1262 FIFO (buffer-offset
-                    # artifact).  Byte 0 varies across receptions of the
-                    # same packet while bytes 1+ are the real payload.
-                    if len(raw) > 1:
-                        raw = raw[1:]
-                    else:
+                    # raw[0] is the RNode header byte.  The lora-sx126x
+                    # driver returns the exact bytes received over the air
+                    # — there is no FIFO offset bug.  (The old raw[1:]
+                    # "spurious byte strip" was actually stripping the
+                    # RNode header, which happened to work for non-split
+                    # packets.)
+                    if len(raw) < 2:
                         await asyncio.sleep(0.05)
                         continue
 
-                    if self._fragment_en:
-                        pkt = self._reassemble(raw)
+                    header = raw[0]
+                    payload = raw[1:]
+
+                    if header & _FLAG_SPLIT:
+                        # Split packet — reassemble 2 frames
+                        seq = header & _SEQ_MASK
+                        if self._reasm_buf is None or self._reasm_seq != seq:
+                            # First fragment (or new seq replaces stale one)
+                            if self._reasm_buf is not None:
+                                log("LoRa split seq mismatch, restarting", LOG_DEBUG)
+                            self._reasm_buf = bytearray(payload)
+                            self._reasm_seq = seq
+                            self._reasm_time = time.time()
+                            log("LoRa split frame 1: " + str(len(payload)) + "B seq=" + hex(seq >> 4), LOG_DEBUG)
+                            pkt = None
+                        else:
+                            # Second fragment — matching sequence
+                            self._reasm_buf.extend(payload)
+                            pkt = bytes(self._reasm_buf)
+                            self._reasm_buf = None
+                            self._reasm_seq = None
+                            log("LoRa split frame 2: " + str(len(payload)) + "B -> " + str(len(pkt)) + "B total", LOG_DEBUG)
                     else:
-                        pkt = raw
+                        # Non-split packet
+                        pkt = payload
 
                     if pkt is not None:
                         _rx_pkt_count += 1

--- a/urns/interfaces/tcp.py
+++ b/urns/interfaces/tcp.py
@@ -109,14 +109,37 @@ class TCPClientInterface(Interface):
             return False
 
         try:
+            # Wrap HDR_1 DATA packets as HDR_2 TRANSPORT when the
+            # destination has a known transport path.  Only TCP needs
+            # this — broadcast interfaces (UDP, LoRa) send HDR_1 directly.
+            # Check: bit 6 = 0 (HDR_1) and bits 0-1 = 0 (PKT_DATA)
+            if len(data) >= 19 and (data[0] & 0x43) == 0x00:
+                from ..transport import Transport
+                transport_id = Transport.path_table.get(data[2:18])
+                if transport_id:
+                    # Set HDR_2 (bit 6) + TRANSPORT (bit 4), keep other bits
+                    data = bytes([data[0] | 0x50]) + data[1:2] + transport_id + data[2:]
+
             frame = bytes([FLAG]) + hdlc_escape(data) + bytes([FLAG])
+            # Switch to blocking mode with timeout for reliable sendall().
+            # MicroPython ESP32 lwIP: sendall() on non-blocking sockets
+            # may silently truncate data if EAGAIN occurs mid-send.
+            self._socket.settimeout(2)
             self._socket.sendall(frame)
+            # Restore non-blocking for poll_loop recv
+            self._socket.settimeout(0)
             self.txb += len(data)
             self.tx += 1
             self._last_activity = time.time()
+            if len(data) >= 18:
+                log("TCP TX " + str(len(data)) + "B frame=" + str(len(frame)) + "B flags=0x" + ("%02x" % data[0]) + " dest=" + data[2:18].hex(), LOG_DEBUG)
             return True
         except Exception as e:
             log("TCP send error: " + str(e), LOG_ERROR)
+            try:
+                self._socket.settimeout(0)
+            except:
+                pass
             self.online = False
             return False
 
@@ -124,7 +147,12 @@ class TCPClientInterface(Interface):
         if self._in_frame and byte == FLAG:
             self._in_frame = False
             if len(self._buffer) > 0:
-                self.process_incoming(bytes(self._buffer))
+                raw = bytes(self._buffer)
+                if len(raw) >= 18:
+                    log("TCP RX " + str(len(raw)) + "B flags=0x" + ("%02x" % raw[0]) + " dest=" + raw[2:18].hex(), LOG_DEBUG)
+                else:
+                    log("TCP RX " + str(len(raw)) + "B", LOG_DEBUG)
+                self.process_incoming(raw)
                 self._buffer = bytearray()
 
         elif byte == FLAG:
@@ -156,6 +184,11 @@ class TCPClientInterface(Interface):
                 continue
 
             try:
+                # Re-assert non-blocking before every recv — ESP32 lwIP
+                # bug: send() corrupts the socket's non-blocking state.
+                # process_outgoing() restores it after sendall(), but
+                # guard here too in case of any edge cases.
+                self._socket.settimeout(0)
                 data = self._socket.recv(512)
                 if data:
                     for b in data:
@@ -170,6 +203,12 @@ class TCPClientInterface(Interface):
                 else:
                     log("TCP recv error: " + str(e), LOG_ERROR)
                     self.online = False
+            except Exception as e:
+                # Catch non-OSError exceptions from the deep call chain
+                # (process_incoming → Transport.inbound → decrypt →
+                # packet.prove → process_outgoing) to prevent the poll
+                # loop from crashing.
+                log("TCP poll error: " + str(e), LOG_ERROR)
 
             await asyncio.sleep(0.01)
 

--- a/urns/link.py
+++ b/urns/link.py
@@ -35,6 +35,8 @@ class Link:
     KEEPALIVE_INTERVAL  = 360   # seconds
     STALE_GRACE         = 720   # seconds
     ESTABLISHMENT_TIMEOUT = 25  # seconds (extra margin for slow ECDH on ESP32)
+    CREATION_COOLDOWN   = 15    # min seconds between link creations (ESP32: ECDH ~5s)
+    _last_creation      = 0
 
     def __init__(self, destination, packet):
         from .identity import Identity
@@ -75,6 +77,30 @@ class Link:
 
         log("Link request on " + destination.hexhash[:8] + " link_id=" + self.link_id.hex()[:8], LOG_VERBOSE)
 
+        # --- Check capacity and rate limit BEFORE expensive crypto ---
+        # ECDH + signing takes ~5s on ESP32, blocking the entire event loop.
+        # Reject early to avoid starving poll loops, announces, and replies.
+        from .transport import Transport
+        if len(Transport.active_links) >= const.MAX_ACTIVE_LINKS:
+            evicted = False
+            for i, l in enumerate(Transport.active_links):
+                if l.status == Link.CLOSED:
+                    Transport.active_links.pop(i)
+                    evicted = True
+                    break
+            if not evicted:
+                log("Active links table full, rejecting link", LOG_ERROR)
+                self.status = Link.CLOSED
+                return
+
+        now = time.time()
+        if now - Link._last_creation < Link.CREATION_COOLDOWN:
+            log("Link request rate limited (" + str(int(Link.CREATION_COOLDOWN - (now - Link._last_creation))) + "s remaining)", LOG_DEBUG)
+            self.status = Link.CLOSED
+            return
+
+        Link._last_creation = now
+
         # Generate ephemeral X25519 keypair for ECDH
         import gc; gc.collect()
         ephemeral_prv = X25519PrivateKey.generate()
@@ -96,18 +122,6 @@ class Link:
         gc.collect()
 
         # Register with Transport
-        from .transport import Transport
-        if len(Transport.active_links) >= const.MAX_ACTIVE_LINKS:
-            evicted = False
-            for i, l in enumerate(Transport.active_links):
-                if l.status == Link.CLOSED:
-                    Transport.active_links.pop(i)
-                    evicted = True
-                    break
-            if not evicted:
-                log("Active links table full, rejecting link", LOG_ERROR)
-                self.status = Link.CLOSED
-                return
         Transport.active_links.append(self)
 
         # Send link proof (packet 2 of handshake)

--- a/urns/transport.py
+++ b/urns/transport.py
@@ -28,6 +28,7 @@ class Transport:
     receipts = []
     announce_table = {}
     destination_table = {}
+    path_table = {}          # dest_hash -> transport_id (from HDR_2 announces)
     blackholed_identities = []
 
     transport_enabled = False
@@ -163,7 +164,7 @@ class Transport:
             if len(raw) < 2:
                 return
 
-            log("Inbound: " + str(len(raw)) + " bytes, flags=0x" + ("%02x" % raw[0]), LOG_DEBUG)
+            log("Inbound: " + str(len(raw)) + " bytes, flags=0x" + ("%02x" % raw[0]), LOG_EXTREME)
 
             # Drop IFAC-tagged packets (bit 7 set). µReticulum does not
             # implement IFAC, so these cannot be decoded. Per reference RNS,
@@ -221,6 +222,17 @@ class Transport:
         gc.collect()
         if valid:
             log("Valid announce from " + packet.destination_hash.hex(), LOG_NOTICE)
+
+            # Record transport path from HDR_2 announces so outbound
+            # DATA packets can be routed via the transport node.
+            if packet.header_type == const.HDR_2 and packet.transport_id:
+                if len(Transport.path_table) < const.MAX_PATH_TABLE or packet.destination_hash in Transport.path_table:
+                    Transport.path_table[packet.destination_hash] = packet.transport_id
+                    log("Path: " + packet.destination_hash.hex()[:8] + " via transport " + packet.transport_id.hex()[:8], LOG_VERBOSE)
+            elif packet.header_type == const.HDR_1:
+                # Direct announce — remove transport path if any
+                Transport.path_table.pop(packet.destination_hash, None)
+
             app_data = Identity.recall_app_data(packet.destination_hash)
             if app_data:
                 log("Announce app_data: " + str(app_data), LOG_VERBOSE)
@@ -247,9 +259,9 @@ class Transport:
 
     @staticmethod
     def _handle_data(packet):
-        import gc; gc.collect()
         for dest in Transport.destinations:
             if dest.hash == packet.destination_hash:
+                import gc; gc.collect()
                 dest.receive(packet)
                 return True
         # Check active links


### PR DESCRIPTION
 ## Summary

  - **LoRa: RNode-compatible split-packet framing** — Replaced the custom fragmentation scheme (SINGLE/FIRST/MIDDLE/LAST) with RNode firmware's exact split-packet protocol. Packets
  up to 500 bytes (Reticulum's full MTU) are now transparently split across two 255-byte LoRa frames using a 1-byte header with random sequence matching. This enables full-size LXMF
  messages over LoRa with RNode interop.

  - **TCP: Transport path routing** — The TCP interface now learns relay paths from HDR_2 announces and automatically wraps outbound DATA packets as HDR_2 TRANSPORT for correct
  delivery through transport servers. Previously, echo replies and other DATA packets were sent as HDR_1 BROADCAST which transport servers don't relay.

  - **Link request rate limiting** — Moved the MAX_ACTIVE_LINKS capacity check and added a 15-second cooldown BEFORE the expensive ECDH crypto (~5s on ESP32), preventing event loop
  starvation from link request floods.

  ## Changes

  ### `urns/interfaces/lora.py` — RNode split-packet protocol
  - Replaced custom SINGLE/FIRST/MIDDLE/LAST fragmentation with RNode's 1-byte header protocol (upper nibble = random sequence, bit 0 = FLAG_SPLIT)
  - Single frame for data ≤ 254B, split into exactly 2 frames for 255–508B
  - Corrected the SX1262 driver understanding: there is no FIFO offset bug — the old `b'\x00'` dummy byte on TX was being sent over the air as a valid RNode header, and the old
  `raw[1:]` on RX was stripping the RNode header
  - Removed the `fragment` config option — RNode protocol is always used

  ### `urns/interfaces/tcp.py` — Transport path routing + reliability
  - `process_outgoing()` wraps HDR_1 DATA packets as HDR_2 TRANSPORT when a transport path is known (TCP-only, does not affect UDP/LoRa)
  - Added `settimeout(2)` before `sendall()` to fix silent data truncation on non-blocking ESP32 lwIP sockets
  - Added debug logging for TX/RX packets
  - Added broad exception handler in poll loop to prevent crashes from deep call chain errors

  ### `urns/transport.py` — Path table + performance
  - Added `path_table` dict to record transport_id from HDR_2 announces
  - HDR_1 announces clear transport paths (direct path preferred)
  - Moved `gc.collect()` in `_handle_data()` to only run after a destination match (was running per-packet)
  - Changed generic inbound log to LOG_EXTREME to reduce noise

  ### `urns/link.py` — Early rejection + rate limiting
  - Moved MAX_ACTIVE_LINKS check BEFORE expensive ECDH crypto
  - Added 15-second CREATION_COOLDOWN between link creations
  - Evicts closed links from the table before rejecting

  ### `example_node.py`
  - Added BME280 sensor support — "sensor" keyword triggers temperature/pressure/humidity reading
  - Sensor data is wired into the echo reply

  ### `README.md`
  - Replaced SX1262 "FIFO offset bug workarounds" section with accurate RNode split-packet protocol documentation
  - Updated TCP, LoRa, and compatibility descriptions

  ## Test plan

  - [x] LoRa announces: ESP32 (SX1262) ↔ RNode (SX1276) bidirectional
  - [x] LoRa LXMF messages with delivery proofs
  - [x] LoRa split-packet: sensor data echo reply (>254B) delivered successfully
  - [x] TCP echo replies arrive via transport server (HDR_2 routing)
  - [x] UDP messaging unaffected by changes
  - [x] All three interfaces (TCP, UDP, LoRa) working simultaneously