### PR TITLE
Add RTC support to example_sensor and correct timestamping for LXMF messages

### DIFF
--- a/firmware/example_sensor.py
+++ b/firmware/example_sensor.py
@@ -24,6 +24,7 @@ Process
 
 from config import WIFI_SSID, WIFI_PASS, NODE_NAME, DEBUG, CONFIG, SENSOR_HUB
 
+import machine, time
 import gc
 gc.collect()
 
@@ -224,9 +225,15 @@ def main():
     rns.setup_interfaces()
     gc.collect()
 
+    # Calling machine.RTC() should set system time from RTC
+    # RTC can be set with mpremote rtc --set
+    rtc = machine.RTC()
+    gc.collect()
+
     if DEBUG >= 1:
         print("LXMF address:", dest.hexhash)
         print("Free memory:", gc.mem_free(), "bytes")
+        print("RTC Time:", rtc.datetime())
         print("Running... (Ctrl+C to stop)")
 
     # Deferred initial announce — runs AFTER poll loop starts

--- a/firmware/urns/lxmf.py
+++ b/firmware/urns/lxmf.py
@@ -157,6 +157,8 @@ class LXMessage:
             elif platform == "rp2":
                 # Micropython on rp2 uses standard unix epoch 1970-01-01
                 self.timestamp = time.time()
+            else:
+                self.timestamp = time.time()
 
         payload = [self.timestamp, self.title, self.content, self.fields]
 

--- a/firmware/urns/lxmf.py
+++ b/firmware/urns/lxmf.py
@@ -2,7 +2,7 @@
 # Wire-compatible with reference LXMF for MeshChat/Sideband interop
 # Supports opportunistic (single-packet) and direct (link) message delivery
 
-import time
+import time, sys
 from . import umsgpack
 from .identity import Identity
 from .destination import Destination
@@ -149,7 +149,14 @@ class LXMessage:
             raise ValueError("Message already packed")
 
         if self.timestamp is None:
-            self.timestamp = time.time()
+            platform = sys.platform
+            # https://docs.micropython.org/en/latest/library/time.html
+            if platform == "esp32":
+                # Micropython on ESP32 uses epoch time of 2000-01-01 so for Unix time need to add 946,684,800 seconds
+                self.timestamp = 946684800 + time.time()
+            elif platform == "rp2":
+                # Micropython on rp2 uses standard unix epoch 1970-01-01
+                self.timestamp = time.time()
 
         payload = [self.timestamp, self.title, self.content, self.fields]
 


### PR DESCRIPTION
Added usage of RTC to set correct system time, adjusted timestamp in lxmf so that messages have correct time. Noted different approaches for ESP32 vs rp2.

Can set RTC with mpremote ('mpremote rtc --set').