### PR TITLE
Added LoRa board preset for Heltec V4

### DIFF
--- a/firmware/config.py
+++ b/firmware/config.py
@@ -133,8 +133,10 @@ CONFIG = {
         #   "xiao_esp32s3_sx1262"          XIAO ESP32-S3 + Wio-SX1262 (kit)
         #   "xiao_esp32s3_sx1262_header"   XIAO ESP32-S3 + Wio-SX1262 (header)
         #   "esp32s3_cam_sx1262"           ESP32-S3 WROOM CAM + Wio-SX1262
+        #   "HTIT-WB32LAF"                 Heltec V4 LoRa HTIT-WB32LAF + SX-1262 embedded
         #
         # Any pin can still be overridden inline (it wins over the preset).
+        #
         {
             "type": "LoRaInterface",
             "board": "esp32s3_cam_sx1262",

--- a/firmware/lora_boards.py
+++ b/firmware/lora_boards.py
@@ -96,5 +96,21 @@ LORA_BOARDS = {
     #     "use_dcdc": True,
     #     "spi_baudrate": 8_000_000,
     # },
+    
+    # HTIT-WB32LAF ESP32-S3 Heltec V4 + LoRa SX1262 + Oled SSD1315.
+    # LoRa has dedicated soldered connection, should be no GPIO conflicts.
+    # Pin map https://heltec.org/wp-content/uploads/2025/09/V4-pinmap-1.png
+    "HTIT-WB32LAF": {
+        "spi_bus": 1,
+        "sck_pin": 9,
+        "mosi_pin": 10,
+        "miso_pin": 11,
+        "cs_pin": 8,
+        "busy_pin": 13,
+        "dio1_pin": 14,
+        "reset_pin": 12,
+        "dio2_rf_sw": True,
+        "dio3_tcxo_millivolts": 1800,
+    },
 
 }


### PR DESCRIPTION
Added preset with link to pin map for Heltec LoRa v4 board HTIT-WB32LAF