### PR TITLE
lora_boards: add the LilyGO T-Deck Pro SX1262 preset

### DIFF
--- a/firmware/lora_boards.py
+++ b/firmware/lora_boards.py
@@ -116,6 +116,37 @@ LORA_BOARDS = {
     },
 
 
+    # LilyGO T-Deck Pro (ESP32-S3 + SX1262). A different board from the T-Deck
+    # v1 above, not a revision: e-ink instead of TFT, TCA8418 keyboard, CST328
+    # touch, and a 2.4V TCXO rather than the v1's 3.3V.
+    #
+    # Two power gates must be driven high before the radio answers at all:
+    # BOARD_1V8_EN (GPIO38) and LORA_EN (GPIO46). A preset cannot express those,
+    # so the application must raise them before building the interface.
+    #
+    # The radio shares SCK (36) with the e-ink panel and the SD card, so pass
+    # "spi"/"spi_acquire"/"spi_release" at runtime for bus arbitration, exactly
+    # as the T-Deck v1 does.
+    #
+    # Battery is a BQ27220 fuel gauge over I2C, not an ADC divider, so there is
+    # deliberately no "battery" block here -- adc_reader.py cannot read it.
+    #
+    # Pins from Meshtastic variants/esp32s3/t-deck-pro/variant.h.
+    "tdeck_pro_sx1262": {
+        "spi_bus": 1,
+        "sck_pin": 36,
+        "mosi_pin": 33,
+        "miso_pin": 47,
+        "cs_pin": 3,
+        "busy_pin": 6,     # variant.h names this LORA_DIO2; it is BUSY
+        "dio1_pin": 5,     # SX1262 IRQ
+        "reset_pin": 4,
+        "dio2_rf_sw": True,
+        "dio3_tcxo_millivolts": 2400,
+        "spi_baudrate": 8_000_000,
+    },
+
+
     # HTIT-WB32LAF ESP32-S3 Heltec V4 + LoRa SX1262 + Oled SSD1315.
     # LoRa has dedicated soldered connection, should be no GPIO conflicts.
     # Pin map https://heltec.org/wp-content/uploads/2025/09/V4-pinmap-1.png


### PR DESCRIPTION
Adds a `lora_boards.py` preset for the LilyGO T-Deck Pro, verified on two of them.

The Pro is a different board from the T-Deck v1 rather than a revision of it: e-ink instead of TFT, a TCA8418 key matrix, and a 2.4V TCXO where the v1 uses 3.3V. Its SX1262 pin map is entirely its own.

Two details in the preset worth calling out:

**Two power gates have to be high before the radio answers at all**, `BOARD_1V8_EN` (GPIO38) and `LORA_EN` (GPIO46). A preset cannot express that, so it is written into the note field for the application to act on. With those left low, a correct pin map reads exactly like a wiring fault, which is worth an hour of anyone's time.

**No `battery` block, on purpose.** The Pro has no ADC divider to sense. Charge comes from a BQ27220 fuel gauge on I2C at 0x55, so a divider entry here would be wrong rather than merely absent.

One correction to the published pin data, since it caught me: Meshtastic's `variants/esp32s3/t-deck-pro/variant.h` gives `PIN_EINK_MOSI 47`, and the panel is actually on GPIO 33, shared with the radio. LilyGO's own header is right about this. It does not affect this preset, but it does affect anything driving the display on the same bus.

Context: this is the radio half of a T-Deck Pro port of `varna9000/reticulum-tdeck`, tracked in [reticulum-tdeck#1](https://github.com/varna9000/reticulum-tdeck/issues/1). The application PR depends on this one and follows it.

Verified on hardware: two decks exchange encrypted LXMF messages over LoRa, and `rnprobe` answers in 1.27 s over 1 hop at RSSI -83 dBm, SNR 12.25 dB.
